### PR TITLE
reply with original method error stack

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -37,7 +37,9 @@ Client.prototype.call = function(name){
     args: args
   }, function(msg){
     if (msg.error) {
-      fn(new Error(msg.error));
+      var err = new Error(msg.error);
+      err.stack = msg.stack || err.stack;
+      fn(err);
     } else {
       msg.args.unshift(null);
       fn.apply(null, msg.args);

--- a/lib/server.js
+++ b/lib/server.js
@@ -86,7 +86,7 @@ Server.prototype.onmessage = function(msg, reply){
 
   // invoke
   args.push(function(err){
-    if (err) return reply({ error: err.message });
+    if (err) return reply({ error: err.message, stack: err.stack });
     var args = [].slice.call(arguments, 1);
     reply({ args: args });
   });


### PR DESCRIPTION
otherwise it's impossible to know where was the error thrown originally in the wrapped api.
