### PR TITLE
axon amp refactor broke axon-rpc

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -13,7 +13,6 @@ module.exports = Client;
  */
 
 function Client(sock) {
-  sock.format('json');
   this.sock = sock;
 }
 

--- a/lib/server.js
+++ b/lib/server.js
@@ -19,7 +19,6 @@ module.exports = Server;
  */
 
 function Server(sock) {
-  sock.format('json');
   this.sock = sock;
   this.methods = {};
   this.sock.on('message', this.onmessage.bind(this));


### PR DESCRIPTION
Looks like axon did amp refactor which eliminated need to do sock.format

https://github.com/visionmedia/axon/commit/879fe2f86fc77123c2267ed19c24a6c49ee6725b 

removing these calls seems to make samples etc... work
