### PR TITLE
Add support for current and older versions of axon.

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -13,6 +13,7 @@ module.exports = Client;
  */
 
 function Client(sock) {
+  if (typeof sock.format === 'function') sock.format('json');
   this.sock = sock;
 }
 

--- a/lib/server.js
+++ b/lib/server.js
@@ -19,6 +19,7 @@ module.exports = Server;
  */
 
 function Server(sock) {
+  if (typeof sock.format === 'function') sock.format('json');
   this.sock = sock;
   this.methods = {};
   this.sock.on('message', this.onmessage.bind(this));

--- a/package.json
+++ b/package.json
@@ -9,12 +9,15 @@
     "commander": "1.0.5"
   },
   "devDependencies": {
-    "axon": "0.5.1",
+    "axon": "2.0.0",
     "better-assert": "*",
     "mocha": "*"
   },
   "bin": {
     "arpc": "bin/arpc"
   },
-  "main": "index"
+  "main": "index",
+  "scripts": {
+    "test": "mocha"
+  }
 }

--- a/test/index.js
+++ b/test/index.js
@@ -11,7 +11,7 @@ var rep = axon.socket('rep');
 var req = axon.socket('req');
 
 rep.bind(4000);
-req.connect(4000);
+req.connect(4000, 'localhost');
 
 var server = new rpc.Server(rep);
 var client = new rpc.Client(req);


### PR DESCRIPTION
The current versions of axon and axon-rpc in npm are incompatible. At the very least, it would be great to get a npm version bump on axon-rpc because master is compatible with the current axon.

---

I added a check for whether the method `sock.format` exists, and only call it if it does. This makes axon-rpc compatible with versions of axon which use AMP while maintaining compatibility with older versions which don't.

I also bumped the version of axon in the dev dependencies to 2.0.0, and added `scripts.test` to package.json to make the tests easier to run.

Lastly, while the tests run fine for me on Linux, they blow up on Windows with:

```
  0 passing (1s)
  5 failing

  1) Server#expose(name, fn) should expose a single function:
     Uncaught Error: connect EADDRNOTAVAIL
      at exports._errnoException (util.js:745:11)
      at Object.afterConnect [as oncomplete] (net.js:995:19)

  2) Server#expose(obj) should expose multiple:
     Uncaught Error: connect EADDRNOTAVAIL
      at exports._errnoException (util.js:745:11)
      at Object.afterConnect [as oncomplete] (net.js:995:19)

  ...
```

Which is caused by the change in axon 1.0.0 to use INADDR_ANY instead of the loopback address for Socket#connect by default. So I explicitly specified localhost for the client in the tests, and now it works on all OS's again.
